### PR TITLE
Fix for a "indirect modification" -error in PHP 5.2

### DIFF
--- a/classes/formo/decorator/html/core.php
+++ b/classes/formo/decorator/html/core.php
@@ -264,7 +264,9 @@ class Formo_Decorator_Html_Core extends Formo_Decorator {
 			? " class=\"$classes_str\""
 			: NULL;
 
-		foreach ($this->attr as $attr => $value)
+		$attrs = $this->attr;
+		
+		foreach ($attrs as $attr => $value)
 		{
 			$valsue = HTML::entities($value);
 			$str.= " $attr=\"$value\"";
@@ -274,7 +276,10 @@ class Formo_Decorator_Html_Core extends Formo_Decorator {
 		if ($this->css)
 		{
 			$str.= ' style="';
-			foreach ($this->css as $style => $value)
+			
+			$styles = $this->css;
+			
+			foreach ($styles as $style => $value)
 			{
 				$str.= "$style:$value;";
 			}


### PR DESCRIPTION
While all's good when using 5.3, decorator/html/core.php throws an "Indirect modification of overloaded property" -error when using 5.2.

Here's a fix.
