### PR TITLE
Untitled

### DIFF
--- a/classes/formo/form/core.php
+++ b/classes/formo/form/core.php
@@ -26,7 +26,7 @@ class Formo_Form_Core extends Formo_Validator {
 		// A model associated with this form
 		'model'               => NULL,
 		// Whether the form was sent
-		'sent'                => Formo::NOTSET,
+		'sent'                => FALSE,
 		// The input object ($_GET/$_POST/etc)
 		'input'               => array(),
 		// If the object should be namespaces


### PR DESCRIPTION
Hi, at the moment the form->sent() method returns boolean TRUE if data has been sent, but returns the string '__NOTSET' if false, rather than boolean FALSE.

Apart from the obvious problems this causes this also results in some odd behavior when using with the formo-jelly adapter and jelly fieldtype validations.

Anyway, this simple patch seems to fix all the issues I was having - hope it's helpful.

Thanks for all your work,

Mark
