### PR TITLE
Make error messages use field labels instead of names

### DIFF
--- a/classes/formo/validator/core.php
+++ b/classes/formo/validator/core.php
@@ -139,6 +139,7 @@ abstract class Formo_Validator_Core extends Formo_Container {
 		{
 			// Bind :model to the model
 			$this->_validation->bind(':model', $driver->model);
+			$this->_validation->labels($driver->model->labels());
 		}
 
 		$this->_validation = $this->_validation->copy($array);


### PR DESCRIPTION
When using the ORM driver, pass the field labels from the ORM model to the Validation object.
