### PR TITLE
Allow HTML5 elements to override the default 'type=text' attribute. 

### DIFF
--- a/classes/formo/driver/text/core.php
+++ b/classes/formo/driver/text/core.php
@@ -12,9 +12,10 @@ class Formo_Driver_Text_Core extends Formo_Driver {
 	
 	public function html()
 	{
+		$type = $this->decorator->attr('type');
 		$this->decorator
 			->set('tag', 'input')
-			->attr('type', 'text')
+			->attr('type', (isset ($type) ? $type : 'text'))
 			->attr('name', $this->name())
 			->attr('value', $this->field->val());
 	}


### PR DESCRIPTION
> This allows an element to receive a 'type' attribute and keep it unchanged when rendering, e.g., 'email', 'tel'.

I've only just picked up Formo so unsure how much this change affects other parts of the library, but on first glance it doesn't break anything.
