### PR TITLE
Fixed #132. If view_prefix is not set within a child object, set the view

### DIFF
--- a/classes/formo/core/driver.php
+++ b/classes/formo/core/driver.php
@@ -413,6 +413,7 @@ abstract class Formo_Core_Driver {
 			$prefix = ($parent = $this->_field->parent())
 				? $parent->get('view_prefix', NULL)
 				: NULL;
+            $this->_field->set('view_prefix', $prefix);
 		}
 
 		// If prefix is still set to NULL and config file has one defined, use the config prefix


### PR DESCRIPTION
Fixed #132. If view_prefix is not set within a child object, set the view_prefix from parent object
