### PR TITLE
changed tag to button from input in Formo_Core_Driver_Submit

### DIFF
--- a/classes/formo/core/driver/submit.php
+++ b/classes/formo/core/driver/submit.php
@@ -12,15 +12,11 @@ class Formo_Core_Driver_Submit extends Formo_Driver {
 
 	public function html()
 	{
-		$value = ($val = $this->_field->get('value'))
-			? $val
-			: $this->_view->label();
-			
 		$this->_view
-			->set_var('tag', 'input')
+			->set_var('tag', 'button')
+			->set_var('text', ($text = $this->_field->val()) ? $text : $this->_view->label())
 			->attr('type', 'submit')
-			->attr('name', $this->name())
-			->attr('value', $value);
+			->attr('name', $this->name());
 	}
 
 	public function sent()


### PR DESCRIPTION
I propose changing input tag in Formo_Driver_Submit to button.

The only reason input type="submit" was so widespread was because of lack of support for button tag [back in the Netscape 4 days](http://kay.smoljak.com/index.php/forget-input-typesubmit-use-a-button/). There were also [several](http://nickcowie.com/2006/the-button-element-and-ie/) [bugs](http://www.peterbe.com/plog/button-tag-in-IE) in IE6 that slowed down the process of moving into proper tag. Nowadays web developers don't care about IE6 anymore as it became a legacy browser with less than few percent of market share and button tag allows more control over [how it renders in the browser](http://particletree.com/features/rediscovering-the-button-element/). Also: it's [recommended by W3C](http://rickyrosario.com/blog/using-the-html-button-element-in-place-of-input-type-submit/).
