### PR TITLE
Fix ORM default value in config

### DIFF
--- a/config/formo.php
+++ b/config/formo.php
@@ -29,7 +29,7 @@ return array
 	// Config file for the ORM driver
 	'orm_config'             => 'formo_kohana',
 	// The default ORM primary val because this bug still isn't fixed in ORM
-	'orm_primary_val'            => 'name',
+	'orm_primary_val'            => 'id',
 	// Auto-generate IDs on form elements
 	'auto_id'                => FALSE,
 	// If set to true, all Validate helper functions are auto-preceded


### PR DESCRIPTION
ID is much more probable choice and it will not throw "The name property does not exist" out of the blue
