### PR TITLE
You need to increment $i if $arg is not set, otherwise everything after a

### DIFF
--- a/classes/formo/core/formo.php
+++ b/classes/formo/core/formo.php
@@ -92,7 +92,10 @@ class Formo_Core_Formo {
 		foreach ($method->getParameters() as $param)
 		{
 			if ( ! isset($args[$i]))
+			{
+				$i++;
 				continue;
+			}
 
 			$new_options = (is_array($args[$i]))
 	            // If the arg was an array and the last param, use it as the set of options


### PR DESCRIPTION
You need to increment $i if $arg is not set, otherwise everything after an 'null' arg will be skipped
