### PR TITLE
Allow Formo::add_rule() to use a syntax similar to Validation::rule().

### DIFF
--- a/classes/Formo/Core/Formo.php
+++ b/classes/Formo/Core/Formo.php
@@ -251,13 +251,27 @@ class Formo_Core_Formo extends Formo_Innards {
 	 * Add a single rule
 	 * 
 	 * @access public
-	 * @param mixed $alias
-	 * @param array $rule (default: NULL)
+	 * @param mixed $rule   (as array like Validation::rules() or string like Validation::rule())
+	 * @param array $params (only used if $rule isn't an array, default: NULL)
 	 * @return Formo obj
 	 */
-	public function add_rule( array $array)
+	public function add_rule($rule, $params = NULL)
 	{
-		$this->_add_rule($array);
+		if (is_array($rule))
+		{
+			$this->_add_rule($rule);
+		}
+		else
+		{
+			if (isset($params))
+			{
+				$this->_add_rule(array($rule, $params));
+			}
+			else
+			{
+				$this->_add_rule(array($rule));
+			}
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
This allows a syntax similar to Validation::rule() and Formo::remove_rule() as

``` php
$field->add_rule($rule);
$field->add_rule($rule, $params);
```

or a syntax similar to Validation::rules() and Formo::add_rules() as

``` php
$field->add_rule(array($rule));
$field->add_rule(array($rule, $params));
```

Not only does this make our implementation code a little cleaner (working on updating Gallery to Kohana 3.3 at https://github.com/gallery/gallery3/tree/kohana_3), but it also makes it easier to extend add_rule().  FWIW, I'm extending add_rule() to allow inline error message definitions (inline as opposed to in message files, that is)...

Thanks!
